### PR TITLE
Typo Fix

### DIFF
--- a/docs/pages/addon/features/version-dependent.md
+++ b/docs/pages/addon/features/version-dependent.md
@@ -59,7 +59,7 @@ Those are the results from this example:
 === ":octicons-file-code-16: VersionedExampleChatExecutor"
     ```java
     @Singleton
-    @Implement(ExampleChatExecutor.class)
+    @Implements(ExampleChatExecutor.class)
     public class VersionedExampleChatExecutor implements ExampleChatExecutor {
     
       @Override


### PR DESCRIPTION
`@Implement` was used in Guice, is `@Implements` now